### PR TITLE
Fix import from garyburd to gomodule

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,7 +1,7 @@
 package tempredis
 
 import (
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 func ExampleUsage() {

--- a/tempredis_test.go
+++ b/tempredis_test.go
@@ -3,7 +3,7 @@ package tempredis
 import (
 	"testing"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 func TestServer(t *testing.T) {


### PR DESCRIPTION
`github.com/garyburd/redigo/redis` is an archived repo. Updating to maintained version at `github.com/gomodule/redigo/redis`