### PR TITLE
Wait for a different ready message introduced in new versions of Redis

### DIFF
--- a/tempredis.go
+++ b/tempredis.go
@@ -12,10 +12,13 @@ import (
 	"syscall"
 )
 
-const (
+var (
 	// ready is the string redis-server prints to stdout after starting
 	// successfully.
-	ready = "The server is now ready to accept connections"
+	ready = []string{
+		"The server is now ready to accept connections",
+		"Ready to accept connections",
+	}
 )
 
 // Server encapsulates the configuration, starting, and stopping of a single
@@ -98,15 +101,17 @@ func writeConfig(config Config, w io.WriteCloser) (err error) {
 }
 
 // waitFor blocks until redis-server prints the given string to stdout.
-func (s *Server) waitFor(search string) (err error) {
+func (s *Server) waitFor(search []string) (err error) {
 	var line string
 
 	scanner := bufio.NewScanner(s.stdout)
 	for scanner.Scan() {
 		line = scanner.Text()
 		fmt.Fprintf(&s.stdoutBuf, "%s\n", line)
-		if strings.Contains(line, search) {
-			return nil
+		for _, s := range search {
+			if strings.Contains(line, s) {
+				return nil
+			}
 		}
 	}
 	err = scanner.Err()


### PR DESCRIPTION
On newer versions of Redis (e.g. on v7.2.1) the ready message is different

```
[...]
15 Oct 2023 12:04:54.895 * DB loaded from disk: 0.000 seconds
15 Oct 2023 12:04:54.895 * Ready to accept connections tcp
15 Oct 2023 12:04:54.895 * Ready to accept connections unix
```

This causes `tempredis` to block in `waitFor` forever. The `waitFor` function looks for the string "The server is now ready to accept connections".

This PR changes `ready` to a slice of strings and adds "Ready to accept connections" as another possible log line to wait for. It also changes `waitFor` accordingly.
