### PR TITLE
Support Redis 7.2 and timeout on startup

### DIFF
--- a/tempredis.go
+++ b/tempredis.go
@@ -12,10 +12,13 @@ import (
 	"syscall"
 )
 
-const (
+var (
 	// ready is the string redis-server prints to stdout after starting
 	// successfully.
-	ready = "The server is now ready to accept connections"
+	ready = []string{
+		"The server is now ready to accept connections",
+		"Ready to accept connections",
+	}
 )
 
 // Server encapsulates the configuration, starting, and stopping of a single
@@ -98,15 +101,17 @@ func writeConfig(config Config, w io.WriteCloser) (err error) {
 }
 
 // waitFor blocks until redis-server prints the given string to stdout.
-func (s *Server) waitFor(search string) (err error) {
+func (s *Server) waitFor(search []string) (err error) {
 	var line string
 
 	scanner := bufio.NewScanner(s.stdout)
 	for scanner.Scan() {
 		line = scanner.Text()
 		fmt.Fprintf(&s.stdoutBuf, "%s\n", line)
-		if strings.Contains(line, search) {
-			return nil
+		for _, s := range search {
+			if strings.Contains(line, s) {
+				return nil
+			}
 		}
 	}
 	err = scanner.Err()


### PR DESCRIPTION
Previously we would stall awaiting Redis 7.2 boot

This prevents that in two ways:
* Support the Redis 7.2 startup message (#3 from @hjr265 – thanks!)
* Add a timeout instead of waiting forever
